### PR TITLE
Update 2024-12-12: Use contextlib.nullcontext (Python 3.7+), Allow setting calibration tx gain

### DIFF
--- a/amodem/__main__.py
+++ b/amodem/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # PYTHON_ARGCOMPLETE_OK
 import argparse
+import contextlib
 import logging
 import os
 import sys
@@ -183,14 +184,6 @@ def create_parser(description, interface_factory):
     return p
 
 
-class _Dummy:
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        pass
-
-
 def _version():
     return pkg_resources.require('amodem')[0].version
 
@@ -240,11 +233,11 @@ def _main():
         from . import alsa  # pylint: disable=import-outside-toplevel
         interface = alsa.Interface(config)
     elif args.audio_library == '-':
-        interface = _Dummy()  # manually disable PortAudio
+        interface = contextlib.nullcontext()  # manually disable PortAudio
     elif args.command == 'send' and args.output is not None:
-        interface = _Dummy()  # redirected output
+        interface = contextlib.nullcontext()  # redirected output
     elif args.command == 'recv' and args.input is not None:
-        interface = _Dummy()  # redirected input
+        interface = contextlib.nullcontext()  # redirected input
     else:
         interface = audio.Interface(config)
         interface.load(args.audio_library)

--- a/amodem/__main__.py
+++ b/amodem/__main__.py
@@ -130,7 +130,8 @@ def create_parser(description, interface_factory):
         ),
         calib=lambda config, args: calib.send(
             config=config, dst=args.dst,
-            volume_cmd=get_volume_cmd(args)
+            volume_cmd=get_volume_cmd(args),
+            gain=args.gain,
         ),
         input_type=FileType('rb'),
         output_type=FileType('wb', interface_factory),


### PR DESCRIPTION
https://github.com/ke4ahr/amodem/commit/297c66c284f8e45366d4a80eb0dbbb487fde1abc
https://github.com/ke4ahr/amodem/commit/1f3ca560e88dc28edee0cf36603d4951639f8d66